### PR TITLE
Feat: 사용자 회원가입/로그인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "mongodb": "^6.16.0",
-        "mongoose": "^8.15.1",
+        "mongoose": "^8.16.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
@@ -5830,6 +5830,7 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
       "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -8672,13 +8673,13 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
-      "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
+      "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
+        "bson": "^6.10.4",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
@@ -8728,14 +8729,14 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.15.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.15.1.tgz",
-      "integrity": "sha512-RhQ4DzmBi5BNGcS0w4u1vdMRIKcteXTCNzDt1j7XRcdWYBz1MjMjulBhPaeC5jBCHOD1yinuOFTTSOWLLGexWw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.16.0.tgz",
+      "integrity": "sha512-gLuAZsbwY0PHjrvfuXvUkUq9tXjyAjN3ioXph5Y6Seu7/Uo8xJaM+rrMbL/x34K4T3UTgtXRyfoq1YU16qKyIw==",
       "license": "MIT",
       "dependencies": {
-        "bson": "^6.10.3",
+        "bson": "^6.10.4",
         "kareem": "2.6.3",
-        "mongodb": "~6.16.0",
+        "mongodb": "~6.17.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "mongodb": "^6.16.0",
-    "mongoose": "^8.15.1",
+    "mongoose": "^8.16.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",

--- a/public/member/find-account.html
+++ b/public/member/find-account.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>아이디 찾기</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/member/style.css">
+</head>
+<body>
+    <div class="form-container">
+        <h1 class="text-center mb-4">아이디 찾기</h1>
+        <form id="find-id-form">
+            <div class="mb-3">
+                <label for="find-id-email" class="form-label">가입 시 등록한 이메일</label>
+                <input type="email" class="form-control" id="find-id-email" placeholder="example@email.com" required>
+            </div>
+            <div class="d-grid">
+                <button type="submit" class="btn btn-primary">아이디 찾기</button>
+            </div>
+        </form>
+        <div id="find-id-message" class="text-center mt-3"></div>
+
+        <p class="mt-5 text-center">
+            <a href="/member/login.html">로그인 페이지로 돌아가기</a>
+        </p>
+    </div>
+
+<script>
+    const findIdForm = document.getElementById('find-id-form');
+    const findIdMessageDiv = document.getElementById('find-id-message');
+    
+    findIdForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        findIdMessageDiv.innerHTML = '';
+        const email = document.getElementById('find-id-email').value;
+        
+        if (!email) {
+            findIdMessageDiv.className = 'alert alert-warning';
+            findIdMessageDiv.textContent = '이메일을 입력해주세요.';
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/members/find-id', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email }),
+            });
+            const data = await response.json();
+            
+            if (response.ok) {
+                findIdMessageDiv.className = 'alert alert-success';
+                findIdMessageDiv.textContent = `회원님의 아이디는 [ ${data.id} ] 입니다.`;
+            } else {
+                findIdMessageDiv.className = 'alert alert-danger';
+                findIdMessageDiv.textContent = data.message || '가입된 계정을 찾을 수 없습니다.';
+            }
+        } catch (error) {
+            findIdMessageDiv.className = 'alert alert-danger';
+            findIdMessageDiv.textContent = '오류가 발생했습니다. 다시 시도해주세요.';
+        }
+    });
+</script>
+</body>
+</html>

--- a/public/member/login.html
+++ b/public/member/login.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>로그인</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/member/style.css">
+</head>
+<body>
+    <div class="form-container">
+        <h1 class="text-center">로그인</h1>
+        <form id="login-form">
+            <div class="mb-3">
+                <label for="id" class="form-label">아이디</label>
+                <input type="text" class="form-control" id="id" required>
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">비밀번호</label>
+                <input type="password" class="form-control" id="password" required>
+            </div>
+            <div class="mb-3 form-check">
+                <input type="checkbox" class="form-check-input" id="remember-me">
+                <label class="form-check-label" for="remember-me">자동 로그인</label>
+            </div>
+            <div class="d-grid">
+                <button type="submit" class="btn btn-primary btn-lg">로그인</button>
+            </div>
+        </form>
+        <div id="message" class="text-center"></div>
+        <div class="text-center mt-3">
+            <a href="find-account.html">아이디 / 비밀번호 찾기</a>
+        </div>
+        <p class="mt-3 text-center">
+            계정이 없으신가요? <a href="/member/signup.html">회원가입</a>
+        </p>
+    </div>
+
+<script>
+    const loginForm = document.getElementById('login-form');
+    const messageDiv = document.getElementById('message');
+
+    loginForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        messageDiv.textContent = '';
+
+        const id = document.getElementById('id').value;
+        const password = document.getElementById('password').value;
+
+        try {
+            const response = await fetch('/api/members/login', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ id, password })
+            });
+
+            const data = await response.json();
+
+            if (response.ok) {
+                // 로그인 성공 시 JWT 토큰을 localStorage에 저장
+                localStorage.setItem('accessToken', data.access_token);
+                
+                messageDiv.textContent = '로그인 성공! 프로필 페이지로 이동합니다.';
+                messageDiv.className = 'alert alert-success';
+                setTimeout(() => {
+                    window.location.href = '/member/profile.html';
+                }, 1000);
+
+            } else {
+                messageDiv.textContent = data.message || '로그인에 실패했습니다.';
+                messageDiv.className = 'alert alert-danger';
+            }
+
+        } catch (error) {
+            messageDiv.textContent = '네트워크 오류가 발생했습니다.';
+            messageDiv.className = 'alert alert-danger';
+        }
+    });
+</script>
+</body>
+</html>

--- a/public/member/profile.html
+++ b/public/member/profile.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>내 프로필</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/member/style.css">
+</head>
+<body>
+    <div class="form-container">
+        <h1 class="text-center">내 프로필</h1>
+        <div id="profile-info" class="text-center fs-4">
+            <p>정보를 불러오는 중입니다...</p>
+        </div>
+        <div class="d-grid mt-4">
+            <button id="logout-btn" class="btn btn-outline-danger">로그아웃</button>
+        </div>
+    </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', async () => {
+        const token = localStorage.getItem('accessToken');
+        const profileInfoDiv = document.getElementById('profile-info');
+
+        // 토큰이 없으면 로그인 페이지로 리다이렉트
+        if (!token) {
+            window.location.href = '/member/login.html';
+            return;
+        }
+
+        try {
+            // 헤더에 JWT 토큰을 담아 프로필 정보 요청
+            const response = await fetch('/api/members/profile', {
+                method: 'GET',
+                headers: {
+                    'Authorization': `Bearer ${token}`
+                }
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                profileInfoDiv.innerHTML = `
+                    <p><strong>아이디:</strong> ${data.id}</p>
+                    <p><strong>닉네임:</strong> ${data.nickname}님 환영합니다!</p>
+                `;
+            } else if (response.status === 401) {
+                // 토큰이 만료되었거나 유효하지 않은 경우
+                alert('세션이 만료되었습니다. 다시 로그인해주세요.');
+                localStorage.removeItem('accessToken');
+                window.location.href = '/member/login.html';
+            } else {
+                profileInfoDiv.innerHTML = '<p class="text-danger">프로필 정보를 불러오는 데 실패했습니다.</p>';
+            }
+
+        } catch (error) {
+            profileInfoDiv.innerHTML = '<p class="text-danger">네트워크 오류가 발생했습니다.</p>';
+        }
+    });
+    
+    // 로그아웃 버튼
+    document.getElementById('logout-btn').addEventListener('click', () => {
+        localStorage.removeItem('accessToken');
+        alert('로그아웃 되었습니다.');
+        window.location.href = '/member/login.html';
+    });
+</script>
+</body>
+</html>

--- a/public/member/signup.html
+++ b/public/member/signup.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>회원가입</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/member/style.css">
+</head>
+<body>
+    <div class="form-container">
+        <h1 class="text-center">회원가입</h1>
+        <form id="signup-form">
+            <div class="mb-3">
+                <label for="id" class="form-label">아이디</label>
+                <input type="text" class="form-control" id="id" required>
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">비밀번호</label>
+                <input type="password" class="form-control" id="password" placeholder="8자 이상 입력" required>
+            </div>
+            <div class="mb-3">
+                <label for="password-check" class="form-label">비밀번호 확인</label>
+                <input type="password" class="form-control" id="password-check" required>
+                <div id="password-message" class="form-text"></div>
+            </div>
+            <div class="mb-3">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" class="form-control" id="email" placeholder="example@email.com" required>
+            </div>
+            <div class="mb-3">
+                <label for="nickname" class="form-label">닉네임</label>
+                <div class="input-group">
+                    <input type="text" class="form-control" id="nickname" required>
+                    <button class="btn btn-outline-secondary" type="button" id="check-nickname-btn">중복 확인</button>
+                </div>
+                <div id="nickname-message" class="form-text"></div>
+            </div>
+            <div class="mb-3">
+                <label for="interests-select" class="form-label">관심분야</label>
+                <select class="form-select" id="interests-select" required>
+                    <option value="" selected disabled>-- 관심분야 --</option>
+                    <option value="정치">정치</option>
+                    <option value="시사">시사</option>
+                    <option value="경제">경제</option>
+                    <option value="스포츠">스포츠</option>
+                    <option value="사회">사회</option>
+                </select>
+            </div>
+
+            <div class="d-grid">
+                <button type="submit" class="btn btn-primary btn-lg">회원가입</button>
+            </div>
+        </form>
+        <div id="message" class="text-center"></div>
+        <p class="mt-3 text-center">
+            이미 계정이 존재하십니까? <a href="/member/login.html">로그인</a>
+        </p>
+    </div>
+
+<script>
+    const signupForm = document.getElementById('signup-form');
+    const messageDiv = document.getElementById('message');
+    const passwordInput = document.getElementById('password');
+    const passwordCheckInput = document.getElementById('password-check');
+    const passwordMessageDiv = document.getElementById('password-message');
+    const checkNicknameBtn = document.getElementById('check-nickname-btn');
+    const nicknameMessageDiv = document.getElementById('nickname-message');
+    const interestsSelect = document.getElementById('interests-select');
+
+    let isNicknameAvailable = false;
+    
+    function checkPasswordMatch() {
+        const password = passwordInput.value;
+        const passwordCheck = passwordCheckInput.value;
+        if (passwordCheck === "") {
+            passwordMessageDiv.textContent = '';
+            return;
+        }
+        if (password === passwordCheck) {
+            passwordMessageDiv.textContent = '비밀번호가 일치합니다.';
+            passwordMessageDiv.className = 'form-text text-success';
+        } else {
+            passwordMessageDiv.textContent = '비밀번호가 일치하지 않습니다.';
+            passwordMessageDiv.className = 'form-text text-danger';
+        }
+    }
+    passwordInput.addEventListener('input', checkPasswordMatch);
+    passwordCheckInput.addEventListener('input', checkPasswordMatch);
+    
+    checkNicknameBtn.addEventListener('click', async () => {
+        const nickname = document.getElementById('nickname').value;
+        if (!nickname) {
+            nicknameMessageDiv.textContent = '닉네임을 입력해주세요.';
+            nicknameMessageDiv.className = 'form-text text-danger';
+            return;
+        }
+
+        try {
+            console.log(`[요청] /api/members/check-nickname?nickname=${nickname}`);
+            const response = await fetch(`/api/members/check-nickname?nickname=${nickname}`);
+            
+            console.log('[응답] 상태 코드:', response.status);
+            
+            if (!response.ok) {
+                throw new Error(`서버 에러: ${response.status}`);
+            }
+
+            const data = await response.json();
+            console.log('[응답] 데이터:', data);
+
+            if (data.isAvailable) {
+                nicknameMessageDiv.textContent = '사용 가능한 닉네임입니다.';
+                nicknameMessageDiv.className = 'form-text text-success';
+                isNicknameAvailable = true;
+            } else {
+                nicknameMessageDiv.textContent = '이미 사용 중인 닉네임입니다.';
+                nicknameMessageDiv.className = 'form-text text-danger';
+                isNicknameAvailable = false;
+            }
+        } catch (error) {
+            console.error('닉네임 확인 오류:', error);
+            nicknameMessageDiv.textContent = '오류가 발생했습니다. 개발자 도구(F12) 콘솔을 확인해주세요.';
+            nicknameMessageDiv.className = 'form-text text-danger';
+            isNicknameAvailable = false;
+        }
+    });
+    
+    document.getElementById('nickname').addEventListener('input', () => {
+        isNicknameAvailable = false;
+        nicknameMessageDiv.textContent = '';
+    });
+    
+    signupForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        messageDiv.textContent = '';
+        
+        if (!isNicknameAvailable) {
+            messageDiv.textContent = '닉네임 중복 확인을 해주세요.';
+            messageDiv.className = 'alert alert-danger';
+            return;
+        }
+        if (passwordInput.value !== passwordCheckInput.value) {
+            messageDiv.textContent = '비밀번호가 일치하지 않습니다.';
+            messageDiv.className = 'alert alert-danger';
+            return;
+        }
+        
+        const selectedInterest = interestsSelect.value;
+        if (selectedInterest === '') {
+            messageDiv.textContent = '관심분야를 선택해주세요.';
+            messageDiv.className = 'alert alert-danger';
+            return;
+        }
+
+        const formData = {
+            id: document.getElementById('id').value,
+            password: passwordInput.value,
+            email: document.getElementById('email').value,
+            nickname: document.getElementById('nickname').value,
+            interests: [selectedInterest]
+        };
+
+        try {
+            const response = await fetch('/api/members/signup', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(formData),
+            });
+            const data = await response.json();
+
+            if (response.ok) {
+                messageDiv.textContent = '2초 뒤 로그인 페이지로 이동합니다.';
+                messageDiv.className = 'alert alert-success';
+                setTimeout(() => { window.location.href = '/member/login.html'; }, 2000);
+            } else {
+                messageDiv.textContent = data.message || '회원가입에 실패했습니다.';
+                messageDiv.className = 'alert alert-danger';
+            }
+        } catch (error) {
+            messageDiv.textContent = '네트워크 오류가 발생했습니다.';
+            messageDiv.className = 'alert alert-danger';
+        }
+    });
+</script>
+</body>
+</html>

--- a/public/member/style.css
+++ b/public/member/style.css
@@ -1,0 +1,28 @@
+html, body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f8f9fa;
+}
+
+.form-container {
+  width: 100%;
+  max-width: 450px;
+  padding: 2rem;
+  background-color: white;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.1);
+}
+
+.form-container h1 {
+    margin-bottom: 1.5rem;
+    font-weight: 700;
+}
+
+#message {
+    margin-top: 1rem;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,9 @@ import { AdminModule } from './admin/admin.module';
 import { AuthModule } from './auth/auth.module';
 import { UserService } from './user/user.service';
 import { UserModule } from './user/user.module';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { MemberModule } from './member/member.module';
 
 @Module({
   imports: [
@@ -19,6 +22,9 @@ import { UserModule } from './user/user.module';
     AdminModule,
     AuthModule,
     UserModule,
+    MemberModule,
   ],
+  controllers: [AppController],
+  providers: [AppService],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,8 +20,17 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 
-  
   app.useStaticAssets(join(__dirname, '..', 'public'));
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  
+  app.enableCors();
 
   await app.listen(3000);
 }

--- a/src/member/dto/create-member.dto.ts
+++ b/src/member/dto/create-member.dto.ts
@@ -1,0 +1,25 @@
+import { IsString, IsEmail, MinLength, MaxLength, IsArray, ArrayNotEmpty, IsIn } from 'class-validator';
+
+export class CreateMemberDto {
+  @IsString()
+  @MinLength(4)
+  @MaxLength(20)
+  id: string;
+
+  @IsString()
+  @MinLength(8, { message: '비밀번호는 8자 이상이어야 합니다.' })
+  password: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(2)
+  @MaxLength(12)
+  nickname: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsIn(['정치', '시사', '경제', '스포츠', '사회'], { each: true })
+  interests: string[];
+}

--- a/src/member/dto/login-member.dto.ts
+++ b/src/member/dto/login-member.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class LoginMemberDto {
+  @IsString()
+  id: string;
+
+  @IsString()
+  @MinLength(8)
+  password: string;
+}

--- a/src/member/guards/member-jwt.auth.guard.ts
+++ b/src/member/guards/member-jwt.auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class MemberJwtAuthGuard extends AuthGuard('member-jwt') {}

--- a/src/member/guards/member-local-auth.guard.ts
+++ b/src/member/guards/member-local-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class MemberLocalAuthGuard extends AuthGuard('member-local') {}

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Post, Body, UseGuards, Request, HttpCode, HttpStatus, Get, Query } from '@nestjs/common';
+import { MemberService } from './member.service';
+import { CreateMemberDto } from './dto/create-member.dto';
+import { MemberLocalAuthGuard } from './guards/member-local-auth.guard';
+import { MemberJwtAuthGuard } from './guards/member-jwt.auth.guard';
+
+@Controller('api/members')
+export class MemberController {
+  constructor(private readonly memberService: MemberService) {}
+
+  @Get('check-nickname')
+  async checkNickname(@Query('nickname') nickname: string) {
+    const member = await this.memberService.findOneByNickname(nickname);
+    
+    return { isAvailable: !member };
+  }
+
+  @Post('signup')
+  async signUp(@Body() createMemberDto: CreateMemberDto) {
+    return this.memberService.signUp(createMemberDto);
+  }
+
+  @UseGuards(MemberLocalAuthGuard)
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  async login(@Request() req) {
+    return this.memberService.login(req.user);
+  }
+
+  @Post('find-id')
+  @HttpCode(HttpStatus.OK)
+  async findId(@Body('email') email: string) {
+    return this.memberService.findIdByEmail(email);
+  }
+
+  @Post('reset-password')
+  @HttpCode(HttpStatus.OK)
+  async resetPassword(@Body('email') email: string) {
+      return this.memberService.resetPassword(email);
+  }
+
+  @UseGuards(MemberJwtAuthGuard)
+  @Get('profile')
+  getProfile(@Request() req) {
+    return req.user;
+  }
+}

--- a/src/member/member.module.ts
+++ b/src/member/member.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Member, MemberSchema } from './schemas/member.schema';
+import { MemberController } from './member.controller';
+import { MemberService } from './member.service';
+import { PassportModule } from '@nestjs/passport';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { MemberLocalStrategy } from './strategies/member-local.strategy';
+import { MemberJwtStrategy } from './strategies/member-jwt.strategy';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Member.name, schema: MemberSchema }]),
+    PassportModule,
+    ConfigModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: configService.get<string>('JWT_EXPIRATION_TIME'),
+        },
+      }),
+    }),
+  ],
+  controllers: [MemberController],
+  providers: [MemberService, MemberLocalStrategy, MemberJwtStrategy],
+})
+export class MemberModule {}

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Member, MemberDocument } from './schemas/member.schema';
+import { CreateMemberDto } from './dto/create-member.dto';
+import * as bcrypt from 'bcrypt';
+import { JwtService } from '@nestjs/jwt';
+
+@Injectable()
+export class MemberService {
+  constructor(
+    @InjectModel(Member.name) private memberModel: Model<MemberDocument>,
+    private jwtService: JwtService,
+  ) {}
+
+  async validateMember(id: string, pass: string): Promise<any> {
+    const member = await this.memberModel.findOne({ id }).exec();
+    if (member && (await bcrypt.compare(pass, member.password))) {
+      const { password, ...result } = member.toObject();
+      return result;
+    }
+    return null;
+  }
+
+  async signUp(createMemberDto: CreateMemberDto) {
+    if (await this.memberModel.findOne({ id: createMemberDto.id }).exec()) {
+      throw new ConflictException('이미 사용중인 아이디입니다.');
+    }
+    if (await this.memberModel.findOne({ email: createMemberDto.email }).exec()) {
+      throw new ConflictException('이미 사용중인 이메일입니다.');
+    }
+    if (await this.memberModel.findOne({ nickname: createMemberDto.nickname }).exec()) {
+      throw new ConflictException('이미 사용중인 닉네임입니다.');
+    }
+
+    const hashedPassword = await bcrypt.hash(createMemberDto.password, 10);
+    const newMember = new this.memberModel({
+      ...createMemberDto,
+      password: hashedPassword,
+    });
+    await newMember.save();
+    return { message: '회원가입이 성공적으로 완료되었습니다.', memberId: newMember.id };
+  }
+  
+  async login(member: Member) {
+    const payload = { id: member.id, sub: member.id, nickname: member.nickname };
+    return {
+      message: '로그인에 성공했습니다.',
+      access_token: this.jwtService.sign(payload),
+    };
+  }
+
+  async findOneByNickname(nickname: string): Promise<Member | null> {
+    return this.memberModel.findOne({ nickname }).exec();
+  }
+  
+  async findIdByEmail(email: string): Promise<{ id: string }> {
+      const member = await this.memberModel.findOne({ email }).exec();
+      if (!member) {
+          throw new NotFoundException('해당 이메일로 가입된 계정을 찾을 수 없습니다.');
+      }
+      return { id: member.id };
+  }
+
+  async resetPassword(email: string): Promise<{ message: string }> {
+    const member = await this.memberModel.findOne({ email }).exec();
+    if (!member) {
+        throw new NotFoundException('해당 이메일로 가입된 계정을 찾을 수 없습니다.');
+    }
+    const tempPassword = Math.random().toString(36).slice(-8);
+    const hashedTempPassword = await bcrypt.hash(tempPassword, 10);
+    await this.memberModel.updateOne({ _id: member._id }, { password: hashedTempPassword });
+    
+    console.log(`[멤버 임시 비밀번호 발급] Email: ${email}, Temp Password: ${tempPassword}`);
+
+    return { message: '가입하신 이메일로 임시 비밀번호가 발송되었습니다.' };
+  }
+}

--- a/src/member/schemas/member.schema.ts
+++ b/src/member/schemas/member.schema.ts
@@ -1,0 +1,24 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type MemberDocument = Member & Document;
+
+@Schema({ timestamps: true, collection: 'members' })
+export class Member {
+  @Prop({ required: true, unique: true, type: String })
+  id: string;
+
+  @Prop({ required: true, type: String })
+  password?: string;
+
+  @Prop({ required: true, unique: true, type: String })
+  email: string;
+
+  @Prop({ required: true, unique: true, type: String })
+  nickname: string;
+
+  @Prop({ required: true, type: [String] })
+  interests: string[];
+}
+
+export const MemberSchema = SchemaFactory.createForClass(Member);

--- a/src/member/strategies/member-jwt.strategy.ts
+++ b/src/member/strategies/member-jwt.strategy.ts
@@ -1,0 +1,27 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class MemberJwtStrategy extends PassportStrategy(Strategy, 'member-jwt') {
+  constructor(private readonly configService: ConfigService) {
+    const secret = configService.get<string>('JWT_SECRET');
+    
+    if (!secret) {
+      throw new InternalServerErrorException(
+        'JWT_SECRET 환경 변수가 설정되지 않았습니다!',
+      );
+    }
+
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: secret,
+    });
+  }
+
+  async validate(payload: any) {
+    return { memberId: payload.sub, id: payload.id, nickname: payload.nickname };
+  }
+}

--- a/src/member/strategies/member-local.strategy.ts
+++ b/src/member/strategies/member-local.strategy.ts
@@ -1,0 +1,19 @@
+import { Strategy } from 'passport-local';
+import { PassportStrategy } from '@nestjs/passport';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { MemberService } from '../member.service';
+
+@Injectable()
+export class MemberLocalStrategy extends PassportStrategy(Strategy, 'member-local') { // 고유 이름 지정
+  constructor(private memberService: MemberService) {
+    super({ usernameField: 'id' });
+  }
+
+  async validate(id: string, password: string): Promise<any> {
+    const member = await this.memberService.validateMember(id, password);
+    if (!member) {
+      throw new UnauthorizedException('아이디 또는 비밀번호가 일치하지 않습니다.');
+    }
+    return member;
+  }
+}


### PR DESCRIPTION
**회원가입**
1. 아이디, 비밀번호, 비밀번호 확인, Email, 닉네임, 관심분야(select 옵션으로 정치, 시사, 경제, 스포츠, 사회 중 선택)를 입력받는다.
2. 닉네임을 입력받을 때 '중복 확인'이라는 버튼을 만들어서 실제로 중복 확인을 진행한다.
3. 회원가입 버튼 아래 '이미 계정이 존재하십니까? 로그인' 로그인을 클릭하면 로그인 페이지로 넘어가도록 한다.

**로그인**
1. 회원가입 시 입력받은 아이디와 비밀번호를 입력받는다.
2. 로그인 버튼 클릭시 DB에 존재하는 아이디와 비밀번호라면 메인 페이지로 넘어가고 그렇지 않다면 아이디 또는 비밀번호가 일치하지 않습니다. 메시지를 출력한다.
3. 아이디 / 비밀번호 찾기 버튼을 클릭하면 Email을 통해 아이디를 찾을 수 있는 기능을 구현한다.
4. 최종적으로 계정이 없으신가요? 회원가입에서 회원가입 버튼을 클릭하면 회원가입 페이지로 이동한다.

JWT 방식으로 구현했으며 더 자세한 내용은 카카오톡 녹화 영상 참고하면 될 듯 합니다.
로그인 성공하면 profile.html로 넘어갈텐데 웹페이지의 main페이지로 리다이렉트하는 걸로 수정해야 합니다.